### PR TITLE
fix：网站管理多选时删除红色按钮红色文字的样式异常

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -19,7 +19,7 @@
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);


### PR DESCRIPTION
fix：红色按钮红色字体的样式异常
![9CYX}DKM`@CNVESPAHGQXYM](https://github.com/user-attachments/assets/5983ea32-c391-4ab7-99cf-103d08fde1bc)
