### PR TITLE
fix: draft fix for replacement rate

### DIFF
--- a/entrypoints/options/components/basic/BasicSettings.vue
+++ b/entrypoints/options/components/basic/BasicSettings.vue
@@ -370,7 +370,7 @@
         <div class="space-y-2">
           <Label for="replacement-rate">
             {{ $t('basicSettings.replacementRate') }} （{{
-              Math.round(settings.replacementRate * 100)
+              settings.replacementRate
             }}%）
           </Label>
           <div class="flex items-center space-x-4">
@@ -381,8 +381,8 @@
                 settings.replacementRate = ($event || [0])[0]
               "
               :min="0"
-              :max="1"
-              :step="0.01"
+              :step="1"
+              :max="10"
               class="flex-1 max-w-[50%]"
             />
           </div>

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -439,14 +439,14 @@ const nativeLanguageOptions = computed(() =>
             <div class="setting-group full-width">
               <label>
                 {{ $t('replacement.rate') }}:
-                {{ Math.round(settings.replacementRate * 100) }}%
+                {{ settings.replacementRate }}
               </label>
               <input
                 type="range"
                 v-model.number="settings.replacementRate"
-                min="0.01"
-                max="1"
-                step="0.01"
+                max="10"
+                min="0"
+                step="1"
               />
             </div>
 

--- a/src/modules/core/translation/PromptService.ts
+++ b/src/modules/core/translation/PromptService.ts
@@ -50,7 +50,6 @@ export class PromptService {
     return `Task: User is learning ${langName}. Given any input text, intelligently select high-value words/phrases (e.g., key nouns, verbs, idioms) for learning, and provide their direct ${langName} translations.
     
 ## Strict Rules
-0. ONLY translate maximum ONE word of given text, if you can't find one, just don't translate anything, it's OK to do nothing. Focus on quality over quota; choose natural whole words/phrases. DO NOT TRANSLATE MORE THAN **ONE** WORD of GIVEN text !!! LESS IS MORE! otherwise my computer will BOOM.
 1. Select based on context: Prioritize words that aid learning, avoid fillers (e.g., 'a', 'the', 'is').
 2. Preserve original code, proper nouns, HTML tags unchanged.
 3. Skip any text already in ${langName}.
@@ -76,10 +75,7 @@ export class PromptService {
       [UserLevel.C2]: 'C2 (Proficient): Select rare or specialized words.',
     };
 
-    let ratioPart = '';
-    if (replacementRate > 0 && replacementRate <= 1) {
-      ratioPart = `ONLY translate maximum ONE word of given text, if you can't find one, just don't translate anything, it's OK to do nothing. Focus on quality over quota; choose natural whole words/phrases. DO NOT TRANSLATE MORE THAN **ONE** WORD of GIVEN text !!! LESS IS MORE! otherwise my computer will BOOM.`;
-    }
+    const ratioPart = `ONLY translate maximum ${replacementRate} word of given text, if you can't find one, just don't translate anything, it's OK to do nothing. Focus on quality over quota; choose natural whole words/phrases. DO NOT TRANSLATE MORE THAN **${replacementRate}** WORD of GIVEN text !!! LESS IS MORE! otherwise my computer will BOOM.`;
 
     return `User Level: ${levelGuidance[userLevel] || levelGuidance[UserLevel.B1]}
 ${ratioPart}`.trim();

--- a/src/modules/shared/constants/defaults.ts
+++ b/src/modules/shared/constants/defaults.ts
@@ -78,7 +78,7 @@ function createDefaultApiConfigItem(): ApiConfigItem {
 // 默认用户设置
 export const DEFAULT_SETTINGS: UserSettings = {
   userLevel: UserLevel.B1,
-  replacementRate: 0.3,
+  replacementRate: 1,
   isEnabled: true,
   useGptApi: true,
   apiConfigs: [createDefaultApiConfigItem()],


### PR DESCRIPTION
This is a DRAFT PR and is NOT yet ready to merge.

Like issues #104, #87, #21, and #70, I also encountered the ineffective `replacement rate` setting. Even if I set it to 1% I still can get below the situation:
<img width="1450" height="808" alt="image" src="https://github.com/user-attachments/assets/99f1d5d4-96e8-4fd4-9e28-3cc97f002c00" />

The model I have tested is: `google/gemini-2.5-flash-lite`, `google/gemini-2.5-flash`, `google/gemini-2.0-flash-001` from the openrouter.

## Causes and solution

**Example prompt problem**: I found in the example prompt, it replaces too many words, which sometimes leads the LLM to replace excessive words, even if the `replacement rate` is low.

https://github.com/xiao-zaiyi/illa-helper/blob/8b379c7ca8943e04019f04cbb402dbcf0cbd85ed/src/modules/core/translation/PromptService.ts#L104C2-L111C32

**Solution**: I just reduced the replaced word in the example to one. There is further improvement of the example prompt, but it works for now.

----

**Replacement rate prompt problem**: As the author's commented, it is hard for a real human to deal with percentages in the situation, not to mention an LLM. 
> 这个翻译比例是组装到提示词发送给 AI，AI 给的翻译，比例不准，这个目前没有什么好方式解决，如果使用代码去验证去掉一部分，这种方法也有一些问题存在，会把比较重要的单词去掉。
 _Originally posted by @xiao-zaiyi in [#87](https://github.com/xiao-zaiyi/illa-helper/issues/87#issuecomment-3101423381)_

**Solution**: I think using a more natural way to instruct LLM on the "replacement rate" could be a solution. There are multiple ways to do this.
1. Use the `number of words per sentence` instead of the percentage for `replacement rate` in both the setting and prompt.
2. Use the `number of words of the provided/given text` instead of the percentage for `replacement rate`  in both the setting and prompt.
3. Use descriptive degree words like: a little, a lot of it, moderate amount instead of percentage for `replacement rate` in the setting, but map those degree words to a range of `number of words per sentence` or `number of words of the provided text`.
4. Expose the `replacement rate` prompt writing to the user by providing some sensible default templates and instructions.

## Result
The PR contains the mentioned solutions 2 for the **replacement rate prompt problem**. 

DEMO for `ONE word of the provided/given text`

<img width="1432" height="859" alt="image" src="https://github.com/user-attachments/assets/0286d09f-d4d6-4bf2-9d52-6feb729c93cd" />

DEMO for `TWO words of the provided/given text`
<img width="1512" height="1019" alt="image" src="https://github.com/user-attachments/assets/53e10936-e8c4-47b1-b40d-f2984a4d2392" />


I found it works quite well with all the models I have tested:  `google/gemini-2.5-flash-lite`, `google/gemini-2.5-flash`, `google/gemini-2.0-flash-001` from the openrouter.
