### PR TITLE
.4381994580705371:fb74a0484410afa3699ec30c13d1411d_69eae02cd0e5e4d04087f2bb.69eae054d0e5e4d04087f2bf.69eae054b92e8945bcf702c4:Trae CN.T(2026/4/24 11:15:32)

### DIFF
--- a/entrypoints/options/components/basic/BasicSettings.vue
+++ b/entrypoints/options/components/basic/BasicSettings.vue
@@ -201,6 +201,24 @@
                     </p>
                   </div>
                 </div>
+                <div class="flex items-start space-x-2">
+                  <RadioGroupItem id="mode-bilingual" value="bilingual" />
+                  <div class="grid gap-1.5 leading-none">
+                    <Label
+                      for="mode-bilingual"
+                      class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                    >
+                      {{ $t('basicSettings.translationModes.bilingual') }}
+                    </Label>
+                    <p class="text-xs text-muted-foreground">
+                      {{
+                        $t(
+                          'basicSettings.translationModes.bilingualDescription',
+                        )
+                      }}
+                    </p>
+                  </div>
+                </div>
               </div>
             </RadioGroup>
           </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "illa-helper",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "illa-helper",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "hasInstallScript": true,
       "dependencies": {
         "@google/generative-ai": "^0.24.1",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -231,7 +231,9 @@
       "word": "Word Translation Mode",
       "wordDescription": "Intelligently select partial words for translation, maintaining original text structure, suitable for language learning",
       "paragraph": "Paragraph Translation Mode",
-      "paragraphDescription": "Translate entire paragraphs, displaying complete translations, suitable for content comprehension"
+      "paragraphDescription": "Translate entire paragraphs, displaying complete translations, suitable for content comprehension",
+      "bilingual": "Bilingual Mode",
+      "bilingualDescription": "Keep original text and display translation side by side, suitable for language learning and document organization"
     },
     "lazyLoading": {}
   },

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -231,7 +231,9 @@
       "word": "单词翻译模式",
       "wordDescription": "智能选择部分单词进行翻译，保持原文结构，适合语言学习",
       "paragraph": "段落翻译模式",
-      "paragraphDescription": "翻译整个段落，显示完整译文，适合内容理解"
+      "paragraphDescription": "翻译整个段落，显示完整译文，适合内容理解",
+      "bilingual": "双语对照模式",
+      "bilingualDescription": "保留原文并显示译文，原文与译文对照展示，适合语言学习与资料整理"
     },
     "lazyLoading": {}
   },

--- a/src/modules/content/ContentManager.ts
+++ b/src/modules/content/ContentManager.ts
@@ -5,6 +5,7 @@ import { StyleManager } from '@/src/modules/styles';
 import { TextProcessorService } from '@/src/modules/core/translation/TextProcessorService';
 import { TextReplacerService } from '@/src/modules/core/translation/TextReplacerService';
 import { ParagraphTranslationService } from '@/src/modules/core/translation/ParagraphTranslationService';
+import { BilingualTranslationService } from '@/src/modules/core/translation/BilingualTranslationService';
 
 import { FloatingBallManager } from '@/src/modules/floatingBall';
 import { WebsiteManager } from '@/src/modules/options/website-management/manager';
@@ -41,6 +42,9 @@ export class TranslationStateManager {
   /** 段落翻译服务引用 */
   private paragraphTranslationService?: ParagraphTranslationService;
 
+  /** 双语对照翻译服务引用 */
+  private bilingualTranslationService?: BilingualTranslationService;
+
   /** 悬浮球管理器引用 */
   private floatingBallManager?: any;
 
@@ -54,10 +58,12 @@ export class TranslationStateManager {
     processingService?: ProcessingService,
     floatingBallManager?: any,
     paragraphTranslationService?: ParagraphTranslationService,
+    bilingualTranslationService?: BilingualTranslationService,
   ) {
     this.processingService = processingService;
     this.floatingBallManager = floatingBallManager;
     this.paragraphTranslationService = paragraphTranslationService;
+    this.bilingualTranslationService = bilingualTranslationService;
   }
 
   /**
@@ -98,6 +104,11 @@ export class TranslationStateManager {
       // 段落翻译模式：使用段落翻译服务
       if (this.paragraphTranslationService) {
         await this.paragraphTranslationService.start();
+      }
+    } else if (settings.translationMode === TranslationMode.BILINGUAL) {
+      // 双语对照模式：使用双语对照翻译服务
+      if (this.bilingualTranslationService) {
+        await this.bilingualTranslationService.start();
       }
     } else {
       // 单词翻译模式：使用原有的处理服务
@@ -147,7 +158,13 @@ export class TranslationStateManager {
     const hasParagraphTranslation =
       document.querySelector('.illa-paragraph-translation') !== null;
 
-    return hasWordTranslation || hasParagraphTranslation;
+    // 检查双语对照翻译内容
+    const hasBilingualTranslation =
+      document.querySelector('.illa-bilingual-translation') !== null;
+
+    return (
+      hasWordTranslation || hasParagraphTranslation || hasBilingualTranslation
+    );
   }
 
   /**
@@ -158,13 +175,17 @@ export class TranslationStateManager {
   }
 
   /**
-   * 清除所有翻译内容（包括段落翻译）
+   * 清除所有翻译内容（包括段落翻译和双语对照翻译）
    */
   public clearAllTranslations(): void {
     try {
       // 清除段落翻译
       if (this.paragraphTranslationService) {
         this.paragraphTranslationService.clearAllTranslations();
+      }
+      // 清除双语对照翻译
+      if (this.bilingualTranslationService) {
+        this.bilingualTranslationService.clearAllTranslations();
       }
     } catch (error) {
       console.error('[ContentManager] 清除翻译失败:', error);
@@ -387,6 +408,10 @@ export class ContentManager implements IContentManager {
     const paragraphTranslationService =
       ParagraphTranslationService.getInstance(lazyLoadingService);
 
+    // 初始化双语对照翻译服务，传递懒加载服务
+    const bilingualTranslationService =
+      BilingualTranslationService.getInstance(lazyLoadingService);
+
     const floatingBallManager = new FloatingBallManager(
       this.settings.floatingBall,
     );
@@ -398,7 +423,8 @@ export class ContentManager implements IContentManager {
       textReplacer,
       floatingBallManager,
       lazyLoadingService,
-      paragraphTranslationService, // 添加段落翻译服务
+      paragraphTranslationService,
+      bilingualTranslationService,
     };
 
     // 创建业务服务
@@ -413,7 +439,8 @@ export class ContentManager implements IContentManager {
     this.translationStateManager = new TranslationStateManager(
       this.processingService,
       this.services.floatingBallManager,
-      this.services.paragraphTranslationService, // 直接传入段落翻译服务
+      this.services.paragraphTranslationService,
+      this.services.bilingualTranslationService,
     );
 
     this.listenerService = new ListenerService(
@@ -498,10 +525,17 @@ export class ContentManager implements IContentManager {
       this.settings.triggerMode === TriggerMode.AUTOMATIC
     ) {
       try {
-        // 判断是单词模式还有还是段落翻译
+        // 根据翻译模式选择不同的服务
         if (this.settings.translationMode === TranslationMode.PARAGRAPH) {
           // 段落翻译模式
           await this.paragraphService.start();
+        } else if (
+          this.settings.translationMode === TranslationMode.BILINGUAL
+        ) {
+          // 双语对照模式
+          if (this.services?.bilingualTranslationService) {
+            await this.services.bilingualTranslationService.start();
+          }
         } else {
           // 单词翻译模式
           await this.processingService.processPage();

--- a/src/modules/content/types.ts
+++ b/src/modules/content/types.ts
@@ -8,6 +8,7 @@ import { StyleManager } from '@/src/modules/styles';
 import { TextProcessorService } from '@/src/modules/core/translation/TextProcessorService';
 import { TextReplacerService } from '@/src/modules/core/translation/TextReplacerService';
 import { ParagraphTranslationService } from '@/src/modules/core/translation/ParagraphTranslationService';
+import { BilingualTranslationService } from '@/src/modules/core/translation/BilingualTranslationService';
 import { FloatingBallManager } from '@/src/modules/floatingBall';
 import { LazyLoadingService } from './services/LazyLoadingService';
 
@@ -59,6 +60,7 @@ export interface ServiceContainer {
   floatingBallManager: FloatingBallManager;
   lazyLoadingService?: LazyLoadingService;
   paragraphTranslationService: ParagraphTranslationService;
+  bilingualTranslationService: BilingualTranslationService;
 }
 
 /**

--- a/src/modules/core/translation/BilingualTranslationService.ts
+++ b/src/modules/core/translation/BilingualTranslationService.ts
@@ -1,0 +1,502 @@
+/**
+ * 双语对照翻译服务
+ *
+ * 设计原则：
+ * 1. 保留原文，同时显示译文，形成对照展示
+ * 2. 与段落翻译模式共用同一套 DOM 获取逻辑
+ * 3. 支持懒加载模式
+ */
+
+import { StorageService } from '../storage';
+import { StyleManager } from '../../styles/core/StyleManager';
+import { ParagraphTranslationApi } from './ParagraphTranslationApi';
+import { BILINGUAL_TRANSLATION } from '../../shared/constants';
+import type { LazyLoadingService } from '../../content/services/LazyLoadingService';
+import type { ContentSegment } from '../../processing/ProcessingStateManager';
+import { globalProcessingState } from '../../processing/ProcessingStateManager';
+import {
+  walkAndCollectParagraphs,
+  collectTextNodes,
+} from '../../processing/DomWalker';
+
+/**
+ * 双语对照翻译服务类
+ */
+export class BilingualTranslationService {
+  private static instance: BilingualTranslationService | null = null;
+  private storageService: StorageService;
+  private styleManager: StyleManager;
+  private paragraphApi: ParagraphTranslationApi;
+  private lazyLoadingService?: LazyLoadingService;
+
+  // 翻译状态管理
+  private isActive: boolean = false;
+  private translatedElements = new WeakSet<HTMLElement>();
+  private translatingElements = new WeakSet<HTMLElement>();
+
+  // 并发配置
+  private readonly BATCH_SIZE = 5;
+  private readonly BATCH_DELAY = 200;
+
+  // 加载指示器样式
+  private readonly LOADING_CLASS = 'illa-bilingual-loading';
+  private readonly LOADING_ICON = `
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="8" cy="8" r="7" stroke="#666" stroke-width="2" stroke-linecap="round" stroke-dasharray="11 11" stroke-dashoffset="0">
+        <animateTransform attributeName="transform" type="rotate" values="0 8 8;360 8 8" dur="1s" repeatCount="indefinite"/>
+      </circle>
+    </svg>
+  `;
+
+  private constructor(lazyLoadingService?: LazyLoadingService) {
+    this.storageService = StorageService.getInstance();
+    this.styleManager = new StyleManager();
+    this.paragraphApi = ParagraphTranslationApi.getInstance();
+    this.lazyLoadingService = lazyLoadingService;
+
+    this.storageService.getUserSettings().then((settings) => {
+      if (settings && settings.translationStyle) {
+        this.styleManager.setTranslationStyle(settings.translationStyle);
+      }
+    });
+  }
+
+  /**
+   * 获取服务实例（单例模式）
+   */
+  public static getInstance(
+    lazyLoadingService?: LazyLoadingService,
+  ): BilingualTranslationService {
+    if (!BilingualTranslationService.instance) {
+      BilingualTranslationService.instance = new BilingualTranslationService(
+        lazyLoadingService,
+      );
+    } else if (
+      lazyLoadingService &&
+      !BilingualTranslationService.instance.lazyLoadingService
+    ) {
+      BilingualTranslationService.instance.lazyLoadingService =
+        lazyLoadingService;
+    }
+    return BilingualTranslationService.instance;
+  }
+
+  /**
+   * 启动双语对照翻译
+   */
+  public async start(): Promise<number> {
+    console.log('[双语对照翻译] 开始启动翻译服务...');
+
+    if (this.isActive) {
+      console.warn('[双语对照翻译] 翻译服务已在运行');
+      return 0;
+    }
+
+    this.isActive = true;
+
+    const settings = await this.storageService.getUserSettings();
+    const isLazyLoadingEnabled =
+      settings?.lazyLoading?.enabled && this.lazyLoadingService?.isEnabled();
+
+    if (isLazyLoadingEnabled) {
+      console.log('[双语对照翻译] 使用懒加载模式');
+      return this.startLazyLoading();
+    } else {
+      console.log('[双语对照翻译] 使用全量翻译模式');
+      return this.startFullTranslation();
+    }
+  }
+
+  /**
+   * 停止双语对照翻译
+   */
+  public stop(): void {
+    this.isActive = false;
+    this.translatedElements = new WeakSet();
+    this.translatingElements = new WeakSet();
+    this.clearAllLoadingIndicators();
+
+    if (this.lazyLoadingService) {
+      this.lazyLoadingService.unobserveSegments([]);
+    }
+
+    console.log('[双语对照翻译] 翻译服务已停止');
+  }
+
+  /**
+   * 清除所有翻译
+   */
+  public clearAllTranslations(): void {
+    document
+      .querySelectorAll(`.${BILINGUAL_TRANSLATION.WRAPPER_CLASS}`)
+      .forEach((el) => el.remove());
+    this.translatedElements = new WeakSet();
+    this.translatingElements = new WeakSet();
+    this.clearAllLoadingIndicators();
+
+    if (this.lazyLoadingService) {
+      this.lazyLoadingService.unobserveSegments([]);
+    }
+
+    console.log('[双语对照翻译] 已清除所有翻译');
+  }
+
+  /**
+   * 查找段落元素 - 基于 DomWalker 统一遍历
+   */
+  private findParagraphElements(): HTMLElement[] {
+    const paragraphs = walkAndCollectParagraphs(document.body);
+
+    const elements = paragraphs
+      .map((p) => p.element)
+      .filter((element) => {
+        if (this.translatedElements.has(element)) return false;
+        if (this.translatingElements.has(element)) return false;
+
+        const text = element.textContent?.trim();
+        if (!text || text.length < 3) return false;
+        if (text.length > 3000) return false;
+
+        if (/^[\d\s.,!?\-+=()[\]{}]*$/.test(text)) return false;
+
+        return true;
+      });
+
+    console.log('[双语对照翻译] 找到段落元素数量:', elements.length);
+    return elements;
+  }
+
+  /**
+   * 翻译元素列表
+   */
+  private async translateElements(elements: HTMLElement[]): Promise<number> {
+    if (elements.length === 0) {
+      return 0;
+    }
+
+    console.log('[双语对照翻译] 开始并发翻译，元素数量:', elements.length);
+
+    const batchSize = this.BATCH_SIZE;
+    let successCount = 0;
+
+    for (let i = 0; i < elements.length; i += batchSize) {
+      const batch = elements.slice(i, i + batchSize);
+      console.log(
+        `[双语对照翻译] 处理批次 ${Math.floor(i / batchSize) + 1}/${Math.ceil(elements.length / batchSize)}，元素数量: ${batch.length}`,
+      );
+
+      const batchPromises = batch.map(async (element) => {
+        try {
+          const success = await this.translateElement(element);
+          return success ? 1 : 0;
+        } catch (error) {
+          console.error('[双语对照翻译] 翻译元素失败:', error);
+          return 0;
+        }
+      });
+
+      const batchResults = await Promise.all(batchPromises);
+      const batchSuccessCount = batchResults.reduce(
+        (sum: number, result: number) => sum + result,
+        0,
+      );
+      successCount += batchSuccessCount;
+
+      if (i + batchSize < elements.length) {
+        await new Promise((resolve) => setTimeout(resolve, this.BATCH_DELAY));
+      }
+    }
+
+    console.log('[双语对照翻译] 并发翻译完成，成功数量:', successCount);
+    return successCount;
+  }
+
+  /**
+   * 翻译单个元素
+   */
+  private async translateElement(element: HTMLElement): Promise<boolean> {
+    if (this.translatedElements.has(element)) {
+      return false;
+    }
+
+    const textContent = element.textContent?.trim();
+    if (!textContent || textContent.length < 5) {
+      return false;
+    }
+
+    this.translatingElements.add(element);
+    this.showLoadingIndicator(element);
+
+    try {
+      console.log(
+        '[双语对照翻译] 翻译元素:',
+        element.tagName,
+        textContent.substring(0, 50),
+      );
+
+      const translatedText =
+        await this.paragraphApi.translateParagraph(textContent);
+
+      if (translatedText && translatedText.trim()) {
+        this.removeLoadingIndicator(element);
+        this.translatingElements.delete(element);
+
+        this.showBilingualTranslation(element, textContent, translatedText);
+        this.translatedElements.add(element);
+        console.log('[双语对照翻译] 翻译成功:', element.tagName);
+        return true;
+      } else {
+        this.removeLoadingIndicator(element);
+        this.translatingElements.delete(element);
+
+        console.log('[双语对照翻译] 翻译结果为空，跳过:', element.tagName);
+        return false;
+      }
+    } catch (error) {
+      this.removeLoadingIndicator(element);
+      this.translatingElements.delete(element);
+
+      console.error(
+        '[双语对照翻译] 翻译失败:',
+        error,
+        '元素:',
+        element.tagName,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * 显示双语对照翻译结果
+   * 保留原文，并在原文下方/旁边显示译文
+   */
+  private showBilingualTranslation(
+    element: HTMLElement,
+    originalText: string,
+    translatedText: string,
+  ): void {
+    element
+      .querySelectorAll(`.${BILINGUAL_TRANSLATION.WRAPPER_CLASS}`)
+      .forEach((el) => el.remove());
+
+    const tagName = element.tagName.toLowerCase();
+    const styleClass = this.styleManager.getCurrentStyleClass();
+
+    let translationElement: HTMLElement;
+
+    if (['table', 'td', 'th', 'li'].includes(tagName)) {
+      const span = document.createElement('span');
+      span.classList.add(
+        BILINGUAL_TRANSLATION.WRAPPER_CLASS,
+        BILINGUAL_TRANSLATION.TRANSLATION_CLASS,
+        styleClass,
+      );
+      span.style.cssText = 'margin-left: 8px; display: inline-block;';
+      span.textContent = ` (${translatedText})`;
+      element.appendChild(span);
+    } else if (['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(tagName)) {
+      translationElement = document.createElement(tagName);
+      translationElement.classList.add(
+        BILINGUAL_TRANSLATION.WRAPPER_CLASS,
+        BILINGUAL_TRANSLATION.TRANSLATION_CLASS,
+        styleClass,
+      );
+      translationElement.textContent = translatedText;
+
+      const computedStyle = window.getComputedStyle(element);
+      translationElement.style.cssText = `
+        margin-top: ${computedStyle.marginTop};
+        margin-bottom: ${computedStyle.marginBottom};
+        font-size: ${computedStyle.fontSize};
+        font-weight: normal;
+        line-height: ${computedStyle.lineHeight};
+        opacity: 0.8;
+      `;
+
+      element.parentNode?.insertBefore(translationElement, element.nextSibling);
+    } else if (
+      ['p', 'div', 'blockquote', 'section', 'article'].includes(tagName)
+    ) {
+      translationElement = document.createElement(tagName);
+      translationElement.classList.add(
+        BILINGUAL_TRANSLATION.WRAPPER_CLASS,
+        BILINGUAL_TRANSLATION.TRANSLATION_CLASS,
+        styleClass,
+      );
+      translationElement.textContent = translatedText;
+
+      const computedStyle = window.getComputedStyle(element);
+      translationElement.style.cssText = `
+        margin-top: ${computedStyle.marginTop};
+        margin-bottom: ${computedStyle.marginBottom};
+        padding: ${computedStyle.padding};
+        opacity: 0.8;
+        font-style: italic;
+      `;
+
+      element.parentNode?.insertBefore(translationElement, element.nextSibling);
+    } else {
+      const div = document.createElement('div');
+      div.classList.add(
+        BILINGUAL_TRANSLATION.WRAPPER_CLASS,
+        BILINGUAL_TRANSLATION.TRANSLATION_CLASS,
+        styleClass,
+      );
+      div.textContent = translatedText;
+      div.style.cssText =
+        'margin-top: 0.5em; margin-bottom: 0.5em; opacity: 0.8; font-style: italic;';
+      element.parentNode?.insertBefore(div, element.nextSibling);
+    }
+
+    element.setAttribute(BILINGUAL_TRANSLATION.MARKER_ATTR, 'true');
+  }
+
+  /**
+   * 显示加载指示器
+   */
+  private showLoadingIndicator(element: HTMLElement): void {
+    this.removeLoadingIndicator(element);
+
+    if (!document.getElementById('illa-bilingual-loading-style')) {
+      const style = document.createElement('style');
+      style.id = 'illa-bilingual-loading-style';
+      style.textContent = `
+        .illa-bilingual-loading svg {
+          animation: illa-bilingual-spin 1s linear infinite;
+        }
+        @keyframes illa-bilingual-spin {
+          100% { transform: rotate(360deg); }
+        }
+        .illa-bilingual-loading {
+          pointer-events: none !important;
+          user-select: none;
+        }
+      `;
+      document.head.appendChild(style);
+    }
+
+    const loadingSpan = document.createElement('span');
+    loadingSpan.classList.add(this.LOADING_CLASS);
+    loadingSpan.innerHTML = this.LOADING_ICON;
+
+    loadingSpan.style.cssText = `
+      display: inline-block;
+      margin-left: 8px;
+      vertical-align: middle;
+      opacity: 0.8;
+    `;
+
+    if (element.tagName.toLowerCase() === 'a') {
+      loadingSpan.style.marginLeft = '4px';
+    }
+
+    element.parentNode?.insertBefore(loadingSpan, element.nextSibling);
+  }
+
+  /**
+   * 移除加载指示器
+   */
+  private removeLoadingIndicator(element: HTMLElement): void {
+    const nextSibling = element.nextSibling;
+    if (nextSibling && nextSibling.nodeType === Node.ELEMENT_NODE) {
+      const nextElement = nextSibling as HTMLElement;
+      if (nextElement.classList.contains(this.LOADING_CLASS)) {
+        nextElement.remove();
+      }
+    }
+  }
+
+  /**
+   * 清除所有加载指示器
+   */
+  private clearAllLoadingIndicators(): void {
+    document
+      .querySelectorAll(`.${this.LOADING_CLASS}`)
+      .forEach((el) => el.remove());
+  }
+
+  /**
+   * 启动全量翻译
+   */
+  private async startFullTranslation(): Promise<number> {
+    const paragraphElements = this.findParagraphElements();
+    console.log(
+      '[双语对照翻译] 全量翻译模式：找到段落元素数量:',
+      paragraphElements.length,
+    );
+
+    const result = await this.translateElements(paragraphElements);
+    console.log('[双语对照翻译] 翻译完成，结果:', result);
+    return result;
+  }
+
+  /**
+   * 启动懒加载翻译
+   */
+  private async startLazyLoading(): Promise<number> {
+    if (!this.lazyLoadingService) {
+      console.warn('[双语对照翻译] 懒加载服务未初始化，回退到全量翻译');
+      return this.startFullTranslation();
+    }
+
+    const paragraphElements = this.findParagraphElements();
+    const segments = this.convertToContentSegments(paragraphElements);
+
+    console.log(
+      '[双语对照翻译] 懒加载模式：找到段落元素数量:',
+      paragraphElements.length,
+    );
+
+    this.lazyLoadingService.setProcessingCallback(
+      async (visibleSegments: ContentSegment[]) => {
+        const elementsToTranslate = visibleSegments.map(
+          (segment) => segment.element as HTMLElement,
+        );
+        await this.translateElements(elementsToTranslate);
+      },
+    );
+
+    this.lazyLoadingService.observeSegments(segments);
+
+    return segments.length;
+  }
+
+  /**
+   * 将段落元素转换为 ContentSegment
+   */
+  private convertToContentSegments(elements: HTMLElement[]): ContentSegment[] {
+    return elements.map((element, index) => {
+      const textContent = element.textContent?.trim() || '';
+      const domPath = globalProcessingState.generateDomPath(element);
+      const fingerprint = globalProcessingState.generateContentFingerprint(
+        textContent,
+        domPath,
+      );
+
+      const textNodes: Text[] = collectTextNodes(element);
+
+      return {
+        id: `${element.tagName.toLowerCase()}-${fingerprint}-${index}`,
+        textContent,
+        element,
+        elements: [element],
+        textNodes,
+        fingerprint,
+        domPath,
+      };
+    });
+  }
+
+  /**
+   * 获取统计信息
+   */
+  public getStats(): { total: number; translated: number } {
+    const total = document.querySelectorAll(
+      'p, h1, h2, h3, h4, h5, h6, div, blockquote, section, article, li, td, th',
+    ).length;
+    const translated = document.querySelectorAll(
+      `.${BILINGUAL_TRANSLATION.WRAPPER_CLASS}`,
+    ).length;
+    return { total, translated };
+  }
+}

--- a/src/modules/shared/constants.ts
+++ b/src/modules/shared/constants.ts
@@ -130,6 +130,7 @@ export const IGNORE_SELECTORS = [
   '[data-wxt-text-processed]',
   '[data-wxt-word-processed]',
   '.illa-paragraph-translation',
+  '.illa-bilingual-translation',
   `[${DOM_LABELS.WALKED}]`,
 ].join(', ');
 
@@ -228,4 +229,28 @@ export const PARAGRAPH_TRANSLATION = {
   WRAPPER_CLASS: 'illa-paragraph-translation',
   CONTENT_CLASS: 'illa-paragraph-content',
   MARKER_ATTR: 'data-illa-translated',
+};
+
+// 双语对照翻译相关常量
+export const BILINGUAL_TRANSLATION = {
+  // 可翻译的元素标签（与段落翻译相同）
+  TRANSLATABLE_TAGS: PARAGRAPH_TRANSLATION.TRANSLATABLE_TAGS,
+
+  // 需要跳过的类名关键词（与段落翻译相同）
+  SKIP_CLASS_KEYWORDS: PARAGRAPH_TRANSLATION.SKIP_CLASS_KEYWORDS,
+
+  // 最小文本长度要求（与段落翻译相同）
+  MIN_TEXT_LENGTH: PARAGRAPH_TRANSLATION.MIN_TEXT_LENGTH,
+
+  // CSS类名
+  WRAPPER_CLASS: 'illa-bilingual-translation',
+  ORIGINAL_CLASS: 'illa-bilingual-original',
+  TRANSLATION_CLASS: 'illa-bilingual-translation-text',
+  MARKER_ATTR: 'data-illa-bilingual',
+
+  // 双语对照模式的样式类
+  STYLE_WRAPPER: 'illa-bilingual-wrapper',
+  STYLE_ORIGINAL: 'illa-bilingual-original-text',
+  STYLE_TRANSLATION: 'illa-bilingual-translation-text',
+  STYLE_SEPARATOR: 'illa-bilingual-separator',
 };

--- a/src/modules/shared/types/core.ts
+++ b/src/modules/shared/types/core.ts
@@ -77,8 +77,9 @@ export enum TranslationPosition {
 
 // 翻译模式枚举
 export enum TranslationMode {
-  WORD = 'word', // 单词/短语翻译模式（当前）
-  PARAGRAPH = 'paragraph', // 段落翻译模式（新增）
+  WORD = 'word', // 单词/短语翻译模式
+  PARAGRAPH = 'paragraph', // 段落翻译模式
+  BILINGUAL = 'bilingual', // 双语对照模式
 }
 
 // 翻译服务提供商枚举


### PR DESCRIPTION
feat(translation): 新增双语对照翻译模式

添加双语对照翻译模式，保留原文并显示译文，适合语言学习与资料整理。包括：
1. 新增 TranslationMode.BILINGUAL 枚举
2. 实现 BilingualTranslationService 核心服务
3. 更新 UI 选项和翻译模式描述
4. 扩展 ContentManager 支持新翻译模式
5. 添加相关样式和国际化配置